### PR TITLE
Version 0.5.1 requires Wine 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-rcedit
 
-Node module to edit resources of exe.
+Node module to edit resources of Windows executables.
 
 ## Building
 
@@ -15,15 +15,17 @@ rcedit = require 'rcedit'
 ```
 On platforms other then Windows you will need to have [Wine](http://winehq.org) installed and in the system path.
 
-### rcedit(exePath, options, callback)
+### `rcedit(exePath, options, callback)`
 
-Change `exePath` with `options`, the `callback` would be called with `(error)`
-when the command is done.
+`exePath` is the path to the Windows executable to be modified.
 
-The `options` is an object that can contain following fields:
+`options` is an object that can contain following fields:
 
-* `version-string` - An object containings properties to change of `exePath`'s
+* `version-string` - An object containing properties to change the `exePath`'s
   version string.
 * `file-version` - File's version to change to.
 * `product-version` - Product's version to change to.
-* `icon` - Path to the icon file to set as `exePath`'s default icon.
+* `icon` - Path to the icon file (`.ico`) to set as the `exePath`'s default icon.
+
+`callback` is the `Function` called when the command completes. The function
+signature is `function (error)`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Node module to edit resources of Windows executables.
 ```coffeescript
 rcedit = require 'rcedit'
 ```
-On platforms other then Windows you will need to have [Wine](http://winehq.org) installed and in the system path.
+On platforms other than Windows, you will need to have [Wine](http://winehq.org)
+1.6 or later installed and in the system path.
 
 ### `rcedit(exePath, options, callback)`
 


### PR DESCRIPTION
As of 0.5.1, running `rcedit` on non-Windows platforms requires Wine 1.6. It does not work with Wine 1.4, which is the latest version of Wine available on Travis CI's default Linux containers. I've added a note to the README to that effect, in addition to cleaning up some of the wording/formatting in general.